### PR TITLE
Fix restrictions

### DIFF
--- a/for-ArcGIS-Pro/Process_MultiNet.py
+++ b/for-ArcGIS-Pro/Process_MultiNet.py
@@ -1085,7 +1085,7 @@ class MultiNetProcessor:
                 # Populate the basic restrictions fields
                 try:
                     # Retrieve the restriction records for this ID
-                    subset_df = self.r_df.loc[id]
+                    subset_df = self.r_df[self.r_df["RESTRTYP"] == "DF"].loc[id]
                     # Loop through all records associated with this ID and update the appropriate restriction fields
                     if isinstance(subset_df, pd.Series):
                         # There was only one record with this ID, so pandas returns a series

--- a/for-ArcGIS-Pro/Process_MultiNet.py
+++ b/for-ArcGIS-Pro/Process_MultiNet.py
@@ -1274,7 +1274,7 @@ class MultiNetProcessor:
                 restriction_values = [None for _ in self.restriction_field_names]
                 try:
                     # Populate the basic restrictions fields
-                    subset_df = self.r_df.loc[id]
+                    subset_df = self.r_df[self.r_df["FEATTYP"].isin([2101, 2103])].loc[id]
                     # Loop through all records associated with this ID and update the appropriate restriction fields
                     if isinstance(subset_df, pd.Series):
                         # There was only one record with this ID, so pandas returns a series

--- a/for-ArcGIS-Pro/Process_MultiNet.py
+++ b/for-ArcGIS-Pro/Process_MultiNet.py
@@ -1,6 +1,6 @@
 """Class to process raw TomTom MultiNet data into a network dataset.
 
-   Copyright 2022 Esri
+   Copyright 2023 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at


### PR DESCRIPTION
Fix a bug in the Pro TomTom MultiNet tool related to populating the restriction fields in Streets:
- FT_AllVehicles_Restricted 
- TF_AllVehicles_Restricted
- FT_PassengerCars_Restricted 
- TF_PassengerCars_Restricted
- FT_ResidentialVehicles_Restricted
- TF_ResidentialVehicles_Restricted
- FT_Taxis_Restricted
- TF_Taxis_Restricted
- FT_PublicBuses_Restricted
- TF_PublicBuses_Restricted

And in RestrictedTurns:
- AllVehicles_Restricted
- PassengerCars_Restricted
- ResidentialVehicles_Restricted
- Taxis_Restricted
- PublicBuses_Restricted

Because of some flawed logic, we neglected to filter out certain rows in the input Restrictions table, which meant that the fields were occasionally populated with a value of "Y" when they should not have been.

For best results, users should reprocess their data with the latest changes.