### PR TITLE
Fix pandas groupby

### DIFF
--- a/for-ArcGIS-Pro/Process_MultiNet.py
+++ b/for-ArcGIS-Pro/Process_MultiNet.py
@@ -1581,6 +1581,10 @@ class MultiNetProcessor:
                     # For each ID in the input sp table, grab the records and build the geometry
                     signpost_oid = 1
                     for id, group in grouped_sp_df:
+                        if isinstance(id, tuple):
+                            # In newer versions of pandas, groupby keys come back as tuples, so just get the first item
+                            # in the tuple
+                            id = id[0]
                         exit_name = None
                         branch_fields = []
                         toward_fields = []

--- a/for-ArcGIS-Pro/Process_MultiNet.py
+++ b/for-ArcGIS-Pro/Process_MultiNet.py
@@ -724,6 +724,11 @@ class MultiNetProcessor:
         with arcpy.da.InsertCursor(self.profiles, output_fields) as cur:
             # Loop through the records in the HSPR table and calculate the SpeedFactor fields accordingly
             for profile_id, group in hspr_df:
+                if isinstance(profile_id, tuple):
+                    # In newer versions of pandas, groupby keys come back as tuples, so just get the first item
+                    # in the tuple
+                    profile_id = profile_id[0]
+
                 # Initialize a new row with the ProfileID and defaulting all the SpeedFactor fields to None.
                 new_row = [profile_id] + [None] * (len(output_fields) - 1)
 


### PR DESCRIPTION
Newer versions of ArcGIS Pro come with a newer version of the pandas package in the default Python environment.  This newer version of pandas alters the values returned when iterating over a groupby object so that instead of the group index value, it returns a tuple.  This was causing errors (see https://github.com/Esri/street-data-processing-tools/issues/56).  Update the code so it works when the returned values are normal types OR tuples.