### PR TITLE
Improve memory management and performance when reading and processing large traffic tables; Remove VBScript from TimeZone attribute

### DIFF
--- a/for-ArcGIS-Pro/NDTemplates/TimeZone_Evaluators_Fields.xml
+++ b/for-ArcGIS-Pro/NDTemplates/TimeZone_Evaluators_Fields.xml
@@ -70,15 +70,19 @@
                 <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
                     <PropertySetProperty xsi:type='typens:PropertySetProperty'>
                         <Key>Version</Key>
-                        <Value xsi:type='xs:short'>1</Value>
+                        <Value xsi:type='xs:short'>2</Value>
                     </PropertySetProperty>
                     <PropertySetProperty xsi:type='typens:PropertySetProperty'>
                         <Key>Expression</Key>
-                        <Value xsi:type='xs:string'>[$FROMFIELD$]</Value>
+                        <Value xsi:type='xs:string'>!$FROMFIELD$!</Value>
                     </PropertySetProperty>
                     <PropertySetProperty xsi:type='typens:PropertySetProperty'>
                         <Key>PreLogic</Key>
                         <Value xsi:type='xs:string'/>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
                     </PropertySetProperty>
                 </PropertyArray>
             </NetworkEvaluatorData>
@@ -94,15 +98,19 @@
                 <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
                     <PropertySetProperty xsi:type='typens:PropertySetProperty'>
                         <Key>Version</Key>
-                        <Value xsi:type='xs:short'>1</Value>
+                        <Value xsi:type='xs:short'>2</Value>
                     </PropertySetProperty>
                     <PropertySetProperty xsi:type='typens:PropertySetProperty'>
                         <Key>Expression</Key>
-                        <Value xsi:type='xs:string'>[$TOFIELD$]</Value>
+                        <Value xsi:type='xs:string'>!$TOFIELD$!</Value>
                     </PropertySetProperty>
                     <PropertySetProperty xsi:type='typens:PropertySetProperty'>
                         <Key>PreLogic</Key>
                         <Value xsi:type='xs:string'/>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
                     </PropertySetProperty>
                 </PropertyArray>
             </NetworkEvaluatorData>

--- a/for-ArcGIS-Pro/Process_HERENavstreetsShp.py
+++ b/for-ArcGIS-Pro/Process_HERENavstreetsShp.py
@@ -1,6 +1,6 @@
 """Class to process raw HERE NAVSTREETS shapefile data into a network dataset.
 
-   Copyright 2024 Esri
+   Copyright 2025 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/for-ArcGIS-Pro/helpers.py
+++ b/for-ArcGIS-Pro/helpers.py
@@ -286,6 +286,7 @@ class StreetDataProcessor:
         with arcpy.da.SearchCursor(self.streets, ["OID@", id_field_name]) as cur:
             id_df = pd.DataFrame(cur, columns=["OID", id_field_name])
         duplicate_streets = id_df[id_df.duplicated(subset=id_field_name)]["OID"].to_list()
+        del id_df
         # If there are any duplicates, delete them.
         if duplicate_streets:
             duplicate_streets = [str(oid) for oid in duplicate_streets]

--- a/for-ArcGIS-Pro/helpers.py
+++ b/for-ArcGIS-Pro/helpers.py
@@ -1,6 +1,6 @@
 """Street data processing tool helper functions
 
-   Copyright 2024 Esri
+   Copyright 2025 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at


### PR DESCRIPTION
For https://github.com/Esri/street-data-processing-tools/issues/62.

Improvements are as follows:
- When reading Link Reference traffic tables, read them in chunks instead of all at once and do various processing tasks per chunk.
- For each chunk, remove records that don't have a matching LINK_ID in Streets since those won't be used anyway.
- For the SPD table, remove all the bazillion H* fields once we're done processing them to free up memory
- When returned records from a query can be either a dataframe or a series, don't turn the series into a dataframe to make the code neater because it makes the processing slower.

With these changes, the user's situation is now workable.  Memory usage remains reasonable, and creating the network for the Germany G1 region finished in about 2.5 hours on my old, slow machine with 32Gb of RAM.

---
Also, I updated the time zone attribute template so it no longer users VBScript evaluators.