### PR TITLE
Avoid arcpy.CheckExtension bug

### DIFF
--- a/for-ArcGIS-Pro/helpers.py
+++ b/for-ArcGIS-Pro/helpers.py
@@ -238,9 +238,9 @@ class StreetDataProcessor:
             return False
 
         # Make sure the license is available.
-        if arcpy.CheckExtension("network").lower() == "available":
+        try:
             arcpy.CheckOutExtension("network")
-        else:
+        except Exception:  # pylint:disable=broad-except
             arcpy.AddError("The Network Analyst extension license is unavailable.")
             return False
 


### PR DESCRIPTION
There's a bug in Pro 3.5 with arcpy.CheckExtension() always returning "NotLicensed" even when the extension license is available (BUG-000176700).  The bug was fixed already in the Pro 3.5.3 patch, so updating to the latest version of Pro will fix the problem.  However, we actually don't need to call arcpy.CheckExtension() at all. We can just use arcpy.CheckOutExtension() with a try/catch.  Update the tool to avoid the bug.